### PR TITLE
add pullapprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,2 @@
+version: 2
+extends: tq-default


### PR DESCRIPTION
The pullapprove status check inherits the default template for the
organization which can be found at https://pullapprove.com/TopicQuests/